### PR TITLE
fixes panic and false positive

### DIFF
--- a/deep_test.go
+++ b/deep_test.go
@@ -625,6 +625,28 @@ func TestInterface(t *testing.T) {
 	}
 }
 
+func TestInterface2(t *testing.T) {
+	defer func() {
+		if val := recover(); val != nil {
+			t.Fatalf("panic: %v", val)
+		}
+	}()
+
+	a := map[string]interface{}{
+		"bar": 1,
+	}
+	b := map[string]interface{}{
+		"bar": 1.23,
+	}
+	diff := deep.Equal(a, b)
+	if len(diff) == 0 {
+		t.Fatalf("expected 1 diff, got zero")
+	}
+	if len(diff) != 1 {
+		t.Errorf("expected 1 diff, got %d", len(diff))
+	}
+}
+
 func TestError(t *testing.T) {
 	a := errors.New("it broke")
 	b := errors.New("it broke")

--- a/deep_test.go
+++ b/deep_test.go
@@ -558,7 +558,7 @@ func TestPointer(t *testing.T) {
 	if len(diff) != 1 {
 		t.Error("too many diff:", diff)
 	}
-	if diff[0] != "<nil pointer> != deep_test.T" {
+	if diff[0] != "<nil pointer> != {1}" {
 		t.Error("wrong diff:", diff[0])
 	}
 
@@ -571,7 +571,7 @@ func TestPointer(t *testing.T) {
 	if len(diff) != 1 {
 		t.Error("too many diff:", diff)
 	}
-	if diff[0] != "deep_test.T != <nil pointer>" {
+	if diff[0] != "{1} != <nil pointer>" {
 		t.Error("wrong diff:", diff[0])
 	}
 
@@ -660,7 +660,9 @@ func TestInterface3(t *testing.T) {
 		t.Fatalf("expected 1 diff, got zero")
 	}
 
-	t.Errorf("expected 1 diff, got: %s", diff)
+	if len(diff) != 1 {
+		t.Errorf("expected 1 diff, got: %s", diff)
+	}
 }
 
 func TestError(t *testing.T) {
@@ -724,8 +726,8 @@ func TestError(t *testing.T) {
 		t.Log(diff)
 		t.Fatalf("expected 1 diff, got %d", len(diff))
 	}
-	if diff[0] != "Error: *errors.errorString != <nil pointer>" {
-		t.Errorf("got '%s', expected 'Error: *errors.errorString != <nil pointer>'", diff[0])
+	if diff[0] != "Error: foo != <nil pointer>" {
+		t.Errorf("got '%s', expected 'Error: foo != <nil pointer>'", diff[0])
 	}
 }
 

--- a/deep_test.go
+++ b/deep_test.go
@@ -647,6 +647,22 @@ func TestInterface2(t *testing.T) {
 	}
 }
 
+func TestInterface3(t *testing.T) {
+	type Value struct{ int }
+	a := map[string]interface{}{
+		"foo": &Value{},
+	}
+	b := map[string]interface{}{
+		"foo": 1.23,
+	}
+	diff := deep.Equal(a, b)
+	if len(diff) == 0 {
+		t.Fatalf("expected 1 diff, got zero")
+	}
+
+	t.Errorf("expected 1 diff, got: %s", diff)
+}
+
 func TestError(t *testing.T) {
 	a := errors.New("it broke")
 	b := errors.New("it broke")


### PR DESCRIPTION
## Problem
1. `deep.Equal` panics on `map[string]interface{}` diff having different value types. See `TestInterface2` 
2. `deep.Equal` skips pointer diff. See `TestInterface3`

```
--- FAIL: TestInterface2 (0.00s)
        deep_test.go:631: panic: reflect: call of reflect.Value.Int on float64 Value
--- FAIL: TestInterface3 (0.00s)
        deep_test.go:660: expected 1 diff, got zero
```

## Solution 
1. do not assume types are equal by calling `c.equal(v1, v2)`
2. compare value pointer points to by calling `c.equal(v1, v2)`

## Notes
1. proposed fix changes how `deep.Equal` reports differences by printing actual values: see `4cc30ce` how it changes expectations
2. the `4cc30ce` is a "quick fix" to make things work, so please let me know how it could be improved…
3. thank you!