### PR TITLE
remove the log.SetFlags(log.Lshortfile).

### DIFF
--- a/deep.go
+++ b/deep.go
@@ -334,9 +334,6 @@ func (c *cmp) saveDiff(aval, bval interface{}) {
 	}
 }
 
-func init() {
-	log.SetFlags(log.Lshortfile)
-}
 
 func logError(err error) {
 	if LogErrors {


### PR DESCRIPTION
  don't change the standard log behavior in a library.