### PR TITLE
failing test illustrating struct field pointer equality bug

### DIFF
--- a/deep_test.go
+++ b/deep_test.go
@@ -912,3 +912,27 @@ func TestNil(t *testing.T) {
 		t.Error("Nil value to comparison should not be equal")
 	}
 }
+
+func TestStructWithPointers(t *testing.T) {
+	type Int struct {
+		value *int
+	}
+	newInt := func(v int) Int {
+		return Int{&v}
+	}
+
+	t1 := newInt(1)
+	t2 := newInt(1)
+
+	diff := deep.Equal(t1, t2)
+	if diff != nil {
+		t.Error("struct field pointers to two of the same values should be equal")
+	}
+
+	t2 = newInt(2)
+
+	diff = deep.Equal(t1, t2)
+	if diff == nil {
+		t.Error("struct field pointers to two different values should not be equal")
+	}
+}


### PR DESCRIPTION
Struct fields that are pointers should be compared for equality, but they're not. This test illustrates the issue: it fails on line 936 because `Int{1}` and `Int{2}` are treated as equal for some reason.

I'm happy to try to figure out what's up and fix it, I just wanted to make sure that this is a real issue and I'm not missing something.