### PR TITLE
Add option that causes nil slices to equal empty slices.

### DIFF
--- a/deep.go
+++ b/deep.go
@@ -276,13 +276,11 @@ func (c *cmp) equals(a, b reflect.Value, level int) {
 			}
 		}
 	case reflect.Slice:
-		aLen := a.Len()
-		bLen := b.Len()
 		if NilSlicesAreEmpty {
-			if a.IsNil() && bLen != 0 {
+			if a.IsNil() && b.Len() != 0 {
 				c.saveDiff("<nil slice>", b)
 				return
-			} else if aLen != 0 && b.IsNil() {
+			} else if a.Len() != 0 && b.IsNil() {
 				c.saveDiff(a, "<nil slice>")
 				return
 			}
@@ -300,6 +298,8 @@ func (c *cmp) equals(a, b reflect.Value, level int) {
 			return
 		}
 
+		aLen := a.Len()
+		bLen := b.Len()
 		n := aLen
 		if bLen > aLen {
 			n = bLen

--- a/deep_test.go
+++ b/deep_test.go
@@ -605,9 +605,12 @@ func TestSlice(t *testing.T) {
 	if diff[0] != "<nil slice> != [1 2 3]" {
 		t.Error("wrong diff:", diff[0])
 	}
+}
 
-	a = a[:1]
-	b = b[:0]
+func TestEmptySlice(t *testing.T) {
+	a := []int{1}
+	b := []int{}
+	var c []int
 
 	diff = deep.Equal(a, b)
 	if diff == nil {

--- a/deep_test.go
+++ b/deep_test.go
@@ -612,6 +612,7 @@ func TestEmptySlice(t *testing.T) {
 	b := []int{}
 	var c []int
 
+	// Non-empty is not equal to empty.
 	diff = deep.Equal(a, b)
 	if diff == nil {
 		t.Fatal("no diff")
@@ -623,6 +624,7 @@ func TestEmptySlice(t *testing.T) {
 		t.Error("wrong diff:", diff[0])
 	}
 
+	// Empty is not equal to non-empty.
 	diff = deep.Equal(b, a)
 	if diff == nil {
 		t.Fatal("no diff")
@@ -634,6 +636,7 @@ func TestEmptySlice(t *testing.T) {
 		t.Error("wrong diff:", diff[0])
 	}
 
+	// Empty is not equal to nil.
 	diff = deep.Equal(b, c)
 	if diff == nil {
 		t.Fatal("no diff")
@@ -645,6 +648,7 @@ func TestEmptySlice(t *testing.T) {
 		t.Error("wrong diff:", diff[0])
 	}
 
+	// Nil is not equal to empty.
 	diff = deep.Equal(c, b)
 	if diff == nil {
 		t.Fatal("no diff")
@@ -666,16 +670,19 @@ func TestNilSlicesAreEmpty(t *testing.T) {
 	b := []int{}
 	var c []int
 
+	// Empty is equal to nil.
 	diff := deep.Equal(b, c)
 	if len(diff) > 0 {
 		t.Error("should be equal:", diff)
 	}
 
+	// Nil is equal to empty.
 	diff = deep.Equal(c, b)
 	if len(diff) > 0 {
 		t.Error("should be equal:", diff)
 	}
 
+	// Non-empty is not equal to nil.
 	diff = deep.Equal(a, c)
 	if diff == nil {
 		t.Fatal("no diff")
@@ -687,6 +694,7 @@ func TestNilSlicesAreEmpty(t *testing.T) {
 		t.Error("wrong diff:", diff[0])
 	}
 
+	// Nil is not equal to non-empty.
 	diff = deep.Equal(c, a)
 	if diff == nil {
 		t.Fatal("no diff")
@@ -698,6 +706,7 @@ func TestNilSlicesAreEmpty(t *testing.T) {
 		t.Error("wrong diff:", diff[0])
 	}
 
+	// Non-empty is not equal to empty.
 	diff = deep.Equal(a, b)
 	if diff == nil {
 		t.Fatal("no diff")
@@ -709,6 +718,7 @@ func TestNilSlicesAreEmpty(t *testing.T) {
 		t.Error("wrong diff:", diff[0])
 	}
 
+	// Empty is not equal to non-empty.
 	diff = deep.Equal(b, a)
 	if diff == nil {
 		t.Fatal("no diff")


### PR DESCRIPTION
Often times when testing, the difference between a slice that is nil and a slice that contains zero elements isn't useful. This change adds the NilSlicesAreEmpty variable, which is initially false to retain backward compatibility. When set to true, slices are compared by length rather than by nilness. Care has been taken to ensure that the resulting diff still indicates that a slice is nil versus empty.
