### PR TITLE
Fix copy pasta error in TestNilMapsAreEmpty

### DIFF
--- a/deep_test.go
+++ b/deep_test.go
@@ -957,9 +957,9 @@ func TestNilSlicesAreEmpty(t *testing.T) {
 }
 
 func TestNilMapsAreEmpty(t *testing.T) {
-	defaultNilMapsAreEmpty := deep.NilSlicesAreEmpty
+	defaultNilMapsAreEmpty := deep.NilMapsAreEmpty
 	deep.NilMapsAreEmpty = true
-	defer func() { deep.NilSlicesAreEmpty = defaultNilMapsAreEmpty }()
+	defer func() { deep.NilMapsAreEmpty = defaultNilMapsAreEmpty }()
 
 	a := map[int]int{1: 1}
 	b := map[int]int{}


### PR DESCRIPTION
I came across what appears to be a copy pasta error in the `TestNilMapsAreEmpty` test. Since the defaults are both the same it's relatively benign, but could surface itself down the road.

Thanks for the great package!