### PR TITLE
Add an option to consider nil pointers to be equivalent to zero values

### DIFF
--- a/deep.go
+++ b/deep.go
@@ -43,6 +43,9 @@ var (
 
 	// NilMapsAreEmpty causes a nil map to be equal to an empty map.
 	NilMapsAreEmpty = false
+
+	// NilPointersAreZero causes a nil pointer to be equal to a zero value.
+	NilPointersAreZero = false
 )
 
 var (
@@ -186,9 +189,15 @@ func (c *cmp) equals(a, b reflect.Value, level int) {
 	if aElem || bElem {
 		if aElem {
 			a = a.Elem()
+			if NilPointersAreZero && !a.IsValid() {
+				a = reflect.Zero(aType.Elem())
+			}
 		}
 		if bElem {
 			b = b.Elem()
+			if NilPointersAreZero && !b.IsValid() {
+				b = reflect.Zero(bType.Elem())
+			}
 		}
 		c.equals(a, b, level+1)
 		return

--- a/deep_test.go
+++ b/deep_test.go
@@ -1581,3 +1581,27 @@ func TestSliceOrderStruct(t *testing.T) {
 		t.Fatalf("expected 0 diff, got %d: %s", len(diff), diff)
 	}
 }
+
+func TestNilPointersAreZero(t *testing.T) {
+	defaultNilPointersAreZero := deep.NilPointersAreZero
+	deep.NilPointersAreZero = true
+	defer func() { deep.NilPointersAreZero = defaultNilPointersAreZero }()
+
+	type T struct {
+		S *string
+	}
+
+	a := T{S: nil}
+	b := T{S: new(string)}
+
+	diff := deep.Equal(a, b)
+	if len(diff) != 0 {
+		t.Fatalf("expected 0 diff, got %d: %s", len(diff), diff)
+	}
+
+	*b.S = "hello"
+	diff = deep.Equal(a, b)
+	if len(diff) != 1 {
+		t.Fatalf("expected 1 diff, got %d: %s", len(diff), diff)
+	}
+}


### PR DESCRIPTION
I have a use-case for go-test/deep that requires me to consider nil and zero values to be equivalent. This PR adds an option + code to achieve this, and tests to verify the behaviour.
